### PR TITLE
Update the ddl to latest changes HDP 2.6.3

### DIFF
--- a/queries.druid/index_ssb.sql
+++ b/queries.druid/index_ssb.sql
@@ -12,7 +12,6 @@ set hive.druid.passiveWaitTimeMs=180000;
 CREATE TABLE ssb_druid
 STORED BY 'org.apache.hadoop.hive.druid.DruidStorageHandler'
 TBLPROPERTIES (
-  "druid.datasource" = "ssb_druid",
   "druid.segment.granularity" = "MONTH",
   "druid.query.granularity" = "DAY")
 AS


### PR DESCRIPTION
Today we had some ppls complaining that this is failing with HDP 2.6.3 due to fact that data source name should not be part of the DDL

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cartershanklin/hive-druid-ssb/1)
<!-- Reviewable:end -->
