### PR TITLE
Use a different place holder for the metadata host

### DIFF
--- a/queries.druid/index_ssb.sql
+++ b/queries.druid/index_ssb.sql
@@ -1,6 +1,6 @@
 set hive.druid.metadata.username=${DRUID_USERNAME};
 set hive.druid.metadata.password=${DRUID_PASSWORD};
-set hive.druid.metadata.uri=jdbc:mysql://${DRUID_HOST}/druid;
+set hive.druid.metadata.uri=jdbc:mysql://${DRUID_METADATA_STORAGE_HOST}/druid;
 set hive.druid.indexer.partition.size.max=1000000;
 set hive.druid.indexer.memory.rownum.max=100000;
 set hive.druid.broker.address.default=${DRUID_HOST}:8082;


### PR DESCRIPTION
Druid_host as placeholder of metadata storage can be confusing, since it is not necessary the same host as other druid nodes

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cartershanklin/hive-druid-ssb/2)
<!-- Reviewable:end -->
